### PR TITLE
New Command class so arguments have no charsub.

### DIFF
--- a/plasTeX/Packages/xy.py
+++ b/plasTeX/Packages/xy.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-from plasTeX import Command, Environment
+from plasTeX import NoCharSubCommand, Command
 
-class xymatrix(Command):
+class xymatrix(NoCharSubCommand):
   args = 'str'
 
   class EndRow(Command):

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -824,7 +824,7 @@ class TeXDocument(Document):
 
     def addPackageResource(self, resource):
         """
-        Adds a pacakge resource or a list of package resources to 
+        Adds a pacakge resource or a list of package resources to
         self.packageResources.
         """
         if isinstance(resource, list):
@@ -935,6 +935,25 @@ class NoCharSubEnvironment(Environment):
         elif self.macroMode == Macro.MODE_END:
             doc.charsubs = self.charsubs
         super(NoCharSubEnvironment, self).invoke(tex)
+
+class NoCharSubCommand(Command):
+    """
+    A subclass of Command which prevents character substituton inside within
+    arguments of the command.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.charsubs = []
+        super(NoCharSubCommand, self).__init__(*args, **kwargs)
+
+    def preArgument(self, arg, tex):
+        self.charsubs = self.ownerDocument.charsubs
+        self.ownerDocument.charsubs = []
+        super(NoCharSubCommand, self).preArgument(arg, tex)
+
+    def postArgument(self, arg, value, tex):
+        self.ownerDocument.charsubs = self.charsubs
+        super(NoCharSubCommand, self).postArgument(arg, value, tex)
 
 class IgnoreCommand(Command):
     """


### PR DESCRIPTION
NoCharSubCommand is like NoCharSubEnvironment in which things in the
command do not undergo character substitution, i.e. certain patterns
(e.g. two dashes) get replaced by unicode counterparts (e.g. an endash).

The xymatrix command, in particular, is made into one such Command. This
fixes xymatrix parsing problems for Stacks Project Tag 0145.