### PR TITLE
Some fixes for #21

### DIFF
--- a/plasTeX/Base/LaTeX/Arrays.py
+++ b/plasTeX/Base/LaTeX/Arrays.py
@@ -19,7 +19,7 @@ class ColumnType(Macro):
         self.style.update(self.columnAttributes)
 
     @classmethod
-    def new(cls, name, attributes, args='', 
+    def new(cls, name, attributes, args='',
             before=None, after=None, between=None):
         """
         Generate a new column type definition
@@ -36,8 +36,8 @@ class ColumnType(Macro):
         """
         newclass = type(name, (cls,),
             {'columnAttributes':attributes, 'args':args,
-             'before': before or [], 
-             'after': after or [], 
+             'before': before or [],
+             'after': after or [],
              'between': between or []})
         cls.columnTypes[name] = newclass
 
@@ -92,7 +92,7 @@ class Array(Environment):
     class EndRow(Command):
         """ End of a row """
         macroName = '\\'
-        args = '* [ space ]'
+        args = '[ ! space ]'
 
         def invoke(self, tex):
             # Pop and push a new context for each row, this keeps

--- a/plasTeX/Packages/xy.py
+++ b/plasTeX/Packages/xy.py
@@ -3,8 +3,44 @@
 from plasTeX import NoCharSubCommand, Command
 
 class xymatrix(NoCharSubCommand):
-  args = 'str'
+  args = '{ str }'
 
   class EndRow(Command):
     """ End of a row """
     macroName = '\\'
+
+  def preArgument(self, arg, tex):
+      # Check whether there are any spacing arguments for xymatrix
+      self.spacingArgs = []
+      for t in tex.itertokens():
+        if t == '{':
+          tex.pushToken(t)
+          break
+        else:
+          self.spacingArgs.append(t)
+      super(xymatrix, self).preArgument(arg, tex)
+
+  def postArgument(self, arg, value, tex):
+      self.argSource = "".join(self.spacingArgs) + self.argSource
+      super(xymatrix, self).postArgument(arg, value, tex)
+
+# These are variants of the xymatrix command in which some spacing parameters
+# are specified before the main argument.
+# See section 3.3 of the "XY-pic User's Guide'.
+class xymatrixR(xymatrix):
+  macroName = "xymatrix@R"
+
+class xymatrixC(xymatrix):
+  macroName = "xymatrix@C"
+
+class xymatrixM(xymatrix):
+  macroName = "xymatrix@M"
+
+class xymatrixW(xymatrix):
+  macroName = "xymatrix@W"
+
+class xymatrixH(xymatrix):
+  macroName = "xymatrix@H"
+
+class xymatrixL(xymatrix):
+  macroName = "xymatrix@L"

--- a/plasTeX/Packages/xy.py
+++ b/plasTeX/Packages/xy.py
@@ -9,6 +9,14 @@ class xymatrix(NoCharSubCommand):
     """ End of a row """
     macroName = '\\'
 
+  class ar(Command):
+    pass
+
+  class omit(Command):
+    @property
+    def source(self):
+      return '\omit'
+
   def preArgument(self, arg, tex):
       # Check whether there are any spacing arguments for xymatrix
       self.spacingArgs = []

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -608,6 +608,10 @@ class Macro(Element):
                 macroargs.append(Argument('*modifier*', index, {'spec':item}))
                 index += 1
 
+            # Do not strip leading whitespace
+            elif item in '!':
+                argdict['stripLeadingWhitespace'] = False
+
             # Optional equals
             elif item in '=':
                 argdict.clear()


### PR DESCRIPTION
These commit fix some of the bugs found in #21. In particular:

- 8f98825 fixes the issues Tags 00RM, 08RM, and 04BL where white space after line breaks in array environments were being devoured;
- 6a8f182 fixes the issues with Tags 08WE, and 08X7 in which `\xymatrix@C` was interpreted as the macro, rather than `\xymatrix`; and
- a24e7c0 fixes the issue with Tag 076P where extra white space is added after the `\omit` command inside the `\xymatrix`.

