### PR TITLE
Place proof header and QED square inside paragraph elements of a proof.

### DIFF
--- a/plasTeX/Renderers/Gerby/Primitives.jinja2s
+++ b/plasTeX/Renderers/Gerby/Primitives.jinja2s
@@ -1,11 +1,13 @@
-name: par 
+name: par
 {% if obj.blockType %}
 {{ obj }}
 {% else %}
-<p>{{ obj }}</p>
+<p>
+{{ obj }}
+</p>
 {% endif %}
 
-name: active::^ 
+name: active::^
 <sup>{{ obj }}</sup>
 
 name: active::_

--- a/plasTeX/Renderers/Gerby/Thms.jinja2s
+++ b/plasTeX/Renderers/Gerby/Thms.jinja2s
@@ -10,13 +10,19 @@ name: thmenv
 
 name: proof
 <article class="env-proof">
-  {% if obj.caption %}
-    <p><strong>{{ obj.caption }}.</strong></p>
-  {% else %}
-    <p><strong>Proof.</strong></p>
-  {% endif %}
-  {{ obj }}
-  <p class="qed">$\square$</p>
+  {% for par in obj %}
+    <p>
+    {% if loop.first %}
+      {% if obj.caption %}
+      <strong>{{ obj.caption }}.</strong>
+      {% else %}
+      <strong>Proof.</strong>
+      {% endif %}
+    {% endif %}
+      {{ par }}
+    {% if loop.last %}
+      <span class="qed">$\square$</span>
+    </p>
+    {% endif %}
+  {% endfor %}
 </article>
-{# FIXME impossible to drop leading <p> of {{ obj }}, needs to be fixed in CSS #}
-{# FIXME if obj is just a single paragraph, there are no <p>'s: the rendering works out fine though, for now #}


### PR DESCRIPTION
Here is some Jinja2 magic that resolves two FIXME's in the proof template. This, combined with a small CSS change, also resolves the improper QED square placement noticed in [#12](https://github.com/pbelmans/gerby-website/issues/12) on ``gerby-website``.