### PR TITLE
Force theorem environments to make paragraphs.

### DIFF
--- a/plasTeX/Base/LaTeX/Definitions.py
+++ b/plasTeX/Base/LaTeX/Definitions.py
@@ -86,11 +86,11 @@ class newtheorem(Command):
         if attrs['*modifier*']:
             newclass = type(str(name), (Environment,),
                     {'caption': caption, 'nodeName': 'thmenv', 'thmName': name,
-                        'args': '[title]'})
+                        'args': '[title]', 'forcePars': True})
         else:
             newclass = type(str(name), (Environment,),
                     {'caption': caption, 'nodeName': 'thmenv', 'thmName': name,
-                        'counter': counter, 'args': '[title]'})
+                        'counter': counter, 'args': '[title]', 'forcePars': True})
         self.ownerDocument.context.addGlobal(name, newclass)
 
 

--- a/plasTeX/Renderers/Gerby/Thms.jinja2s
+++ b/plasTeX/Renderers/Gerby/Thms.jinja2s
@@ -1,11 +1,17 @@
 name: thmenv
 <article class="env-{{ obj.thmName }}" id="{{ obj.userdata['tag'] }}">
-  {% if obj.title %}
-    <p><a class="environment-identifier" href="/tag/{{ obj.userdata['tag'] }}">{{ obj.thmName|capitalize }} <span data-tag="{{ obj.userdata['tag'] }}">{{ obj.ref }}</span> <span class="named">({{ obj.title }})</span>.</a>
-  {% else %}
-    <p><a class="environment-identifier" href="/tag/{{ obj.userdata['tag'] }}">{{ obj.thmName|capitalize }} <span data-tag="{{ obj.userdata['tag'] }}">{{ obj.ref }}</span>.</a>
-  {% endif %}
-  {{ obj }}
+  {% for par in obj %}
+    <p>
+    {% if loop.first %}
+      {% if obj.title %}
+    <a class="environment-identifier" href="/tag/{{ obj.userdata['tag'] }}">{{ obj.thmName|capitalize }} <span data-tag="{{ obj.userdata['tag'] }}">{{ obj.ref }}</span> <span class="named">({{ obj.title }})</span>.</a>
+      {% else %}
+    <a class="environment-identifier" href="/tag/{{ obj.userdata['tag'] }}">{{ obj.thmName|capitalize }} <span data-tag="{{ obj.userdata['tag'] }}">{{ obj.ref }}</span>.</a>
+      {% endif %}
+    {% endif %}
+    {{ par }}
+    </p>
+  {% endfor %}
 </article>
 
 name: proof


### PR DESCRIPTION
This patch forces theorem environments to always group text into
paragraphs. This fixes an inconsistent spacing issue for when theorem
environments naturally have multiple paragraphs, fixing #38 and, presumably, #31.